### PR TITLE
 Changed activeRequests from Map to HashMap 

### DIFF
--- a/src/App.hs
+++ b/src/App.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -60,10 +61,10 @@ data HelpRequest = HelpRequest { reqid :: RequestID, userid :: Identification, t
   deriving (Generic, Show, Eq)
 instance ToJSON HelpRequest
 
-data Responder = Responder String
+newtype Responder = Responder String
   deriving (Generic, Show, Eq, Ord)
+  deriving ToJSONKey via String
 instance ToJSON Responder
-instance ToJSONKey Responder
 
 data State = State { lectureName     :: String
                    , timeSlots       :: [TimeRange]

--- a/www/static/adorabelle.js
+++ b/www/static/adorabelle.js
@@ -306,21 +306,16 @@ function formatBacklogItem(item) {
 var seenAdmins = [];
 
 function updateServicedRequests(servicedRequests) {
-	var dict = new Object();
-	servicedRequests.forEach(function (item, index) {
-		dict[item[0]] = item[1];
-	});
-
 	var order;
 	if (admininterface) {
-		Object.keys(dict).forEach(function (elem) {
+		Object.keys(servicedRequests).forEach(function (elem) {
 			if(!seenAdmins.includes(elem)) {
 				seenAdmins.push(elem);
 			}
 		});
 		order = seenAdmins;
 	} else {
-		order = Object.keys(dict).sort();
+		order = Object.keys(servicedRequests).sort();
 	}
 
 	var elem = $('#servicedReqs').clone().empty();
@@ -328,8 +323,8 @@ function updateServicedRequests(servicedRequests) {
 		var lbl = $('<label class="d-flex justify-content-start col-form-label-lg"/>');
 		lbl.text(key);
 		elem.append(lbl);
-		if (key in dict) {
-			elem.append(formatRequest(dict[key], "active"));
+		if (key in servicedRequests) {
+			elem.append(formatRequest(servicedRequests[key], "active"));
 		} else {
 			elem.append(formatRequest(undefined, "dummy"));
 		}


### PR DESCRIPTION
Hi again,

I'm working on a little client for Adora Belle, but the fact that `activeRequests` is represented as an associative list makes it rather hard to use in statically typed language (such as Go). As far as I understand, Aeson is generating this because `activeRequests` are represented by a Data.Map structure. From reading the Aeson documentation, I think that this can be fixed by changing the container to a HashMap. So this change set should translate every Data.Map operation into an analogous HashMap operation.

The frontend code was also modified to adapt to this change, but it seems I had to remove more code than add any.

As mentioned in my last pull request, I cannot really test it, but my Haskell setup didn't complain about any type errors. 