### PR TITLE
Fix styling of footer on small screens

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -113,8 +113,10 @@
 	</div>
 
 	<footer class="footer">
-	  <div class="container">
-		<span class="text-muted">Adora-Belle is <a href="https://www.fsf.org/about/what-is-free-software" target="_blank">Free-Software</a> and <a href="https://github.com/noctux/adora-belle" target="_blank">available</a> under the Terms and Conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html" target="_blank">AGPL3 License</a>.</span>
+	  <div class="footer-inner">
+		<div class="container">
+		  <span class="text-muted">Adora-Belle is <a href="https://www.fsf.org/about/what-is-free-software" target="_blank">Free-Software</a> and <a href="https://github.com/noctux/adora-belle" target="_blank">available</a> under the Terms and Conditions of the <a href="https://www.gnu.org/licenses/agpl-3.0.en.html" target="_blank">AGPL3 License</a>.</span>
+		</div>
 	  </div>
 	</footer>
 
@@ -130,9 +132,15 @@
 		  position: absolute;
 		  bottom: 0;
 		  width: 100%;
-		  height: 60px; /* Set the fixed height of the footer here */
-		  line-height: 60px; /* Vertically center the text there */
+		  height: 60px; /* Set the standard height of the footer here. The content can still overflow */
 		  background-color: #f5f5f5;
+	  }
+	  .footer-inner {
+		  background-color: #f5f5f5;
+	  }
+	  .footer-inner > .container {
+		padding-top: 18px;
+		padding-bottom: 18px;
 	  }
 	</style>
 


### PR DESCRIPTION
On screens with a small width the footer reflows into multiple lines which caused it to leave the lightgray footer area.

These additional lines might overflow the initial viewport such that the AGPL3 license hint is only visible after scrolling downwards.