### PR TITLE
Prevent crash if cookies are disabled in a browser

### DIFF
--- a/www/static/adorabelle.js
+++ b/www/static/adorabelle.js
@@ -5,8 +5,15 @@ var preferences = {
 	markrecentlydeferred: false,
 };
 function loadPreferences() {
+	var stored;
+	var supported = false;
 	if (typeof(Storage) !== "undefined") {
-		var stored = localStorage.getItem("preferences");
+		try {
+			stored = localStorage.getItem("preferences");
+			supported = true;
+		} catch (e) {}
+	}
+	if (supported) {
 		if (stored) {
 			try {
 				var parsed = JSON.parse(stored);


### PR DESCRIPTION
If setting cookies is forbidden, Firefox/Safari/? throw an exception when trying to access localStorage.

See for example: https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document