### PR TITLE
Tweak login form

### DIFF
--- a/www/static/adorabelle.js
+++ b/www/static/adorabelle.js
@@ -507,7 +507,6 @@ $('#loginform').on('submit', function(event) {
 		initApi(user, pw);
 		$('#loginModal').modal('hide');
 	} else {
-		$('#usernameInput').val('');
 		$('#passwordInput').val('');
 	}
 });

--- a/www/static/adorabelle.js
+++ b/www/static/adorabelle.js
@@ -511,6 +511,10 @@ $('#loginform').on('submit', function(event) {
 	}
 });
 
+$('#loginModal').on('shown.bs.modal', function () {
+	$('#usernameInput').trigger('focus');
+});
+
 setupPreferencesmodal();
 
 var storeduser = getPreference('username');


### PR DESCRIPTION
This auto-focuses the username field when the login modal is shown. In addition, a failed login only clears the password and not also the username. This allows fixing user name typos.