### PR TITLE
Fix first notification sound

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -112,6 +112,18 @@
 	  </div>
 	</div>
 
+
+	<!-- Sound autoplay modal interface, only shown to enforce user interaction -->
+	<div class="modal fade" id="autoPlayModal" tabindex="-1" role="dialog" aria-labelledby="autoPlayModalLabel" aria-hidden="true">
+		<div class="modal-dialog modal-dialog-centered" role="document">
+		  <div class="modal-content">
+			<div class="modal-header">
+			  <h5 class="modal-title" id="autoPlayModalLabel">Please click outside to close this dialog. Sound notifications won't work before the first interaction with the website</h5>
+			</div>
+		  </div>
+		</div>
+	  </div>
+
 	<footer class="footer">
 	  <div class="footer-inner">
 		<div class="container">

--- a/www/static/adorabelle.js
+++ b/www/static/adorabelle.js
@@ -520,6 +520,9 @@ var storeduser = getPreference('username');
 var storedpw   = getPreference('password');
 if (storeduser && storedpw && testBasicCredentials(informationendpoint, storeduser, storedpw)) {
 	initApi(storeduser, storedpw);
+	if (admininterface && getPreference('usesound')) {
+		$('#autoPlayModal').modal('show');
+	}
 } else {
 	$('#loginModal').modal({ show: false});
 	$('#loginModal').modal('show');

--- a/www/static/adorabelle.js
+++ b/www/static/adorabelle.js
@@ -332,6 +332,7 @@ function updateServicedRequests(servicedRequests) {
 }
 
 const seen = new Set();
+let firstUpdate = true;
 
 function updatePendingRequests(pendingRequests) {
 	var elem = $('#pendingReqs').clone().empty();
@@ -342,9 +343,10 @@ function updatePendingRequests(pendingRequests) {
 		}
 		elem.append(formatRequest(x, "pending"));
 	});
-	if (admininterface && getPreference('usesound') && before != 0 && seen.size > before) {
+	if (admininterface && getPreference('usesound') && !firstUpdate && seen.size > before) {
 		new Audio("static/sound.opus").play();
 	}
+	firstUpdate = false;
 	$('#pendingReqs').replaceWith(elem);
 }
 


### PR DESCRIPTION
There are two separate issues here:
- The code ensured that the notification sound is not played when loading the page while requests are already pending. However, this also blocked the notification playback for the first incoming request.
- Fixing this leads to another problem: Browser (by default) only permit audio playback after the first user interaction. If Adora Belle is configured to store the login credentials, then there's no need for the user to make this first interaction which once again causes the first notification sound to be blocked (or to be more precise: all notification sounds until the user clicks somewhere inside the website). The workaround here is to ask the user to click inside the website if the notification sound is enabled and login credentials are stored. Unfortunately, there seems to be no browser API to check whether the user has granted the autoplay permission to Adora Belle.